### PR TITLE
Idle mode now handled entirely by default command

### DIFF
--- a/RapidReact/src/main/java/frc/robot/RobotContainer.java
+++ b/RapidReact/src/main/java/frc/robot/RobotContainer.java
@@ -17,7 +17,7 @@ import frc.robot.commands.AutoAlignWithHubCommand;
 import frc.robot.commands.AutoIntakeCommand;
 import frc.robot.commands.AutoShootCommand;
 import frc.robot.commands.DefaultDriveCommand;
-import frc.robot.commands.DefaultShooterCommand;
+import frc.robot.commands.IdleShooterCommand;
 import frc.robot.commands.ExtendElevatorCommand;
 import frc.robot.commands.HomeElevatorCommand;
 import frc.robot.commands.FollowerCommand;
@@ -148,7 +148,7 @@ public class RobotContainer {
                 () -> -driveControllerHelper.scaleAxis(driveController.getRightX()) * drivetrain.maxAngularVelocity * 0.8));
 
         // create idle shoot command
-        shooter.setDefaultCommand(new DefaultShooterCommand(shooter));
+        shooter.setDefaultCommand(new IdleShooterCommand(shooter));
 
         // Create the command to deploy the climber
 
@@ -303,10 +303,9 @@ public class RobotContainer {
 
     private Command createShootOnlyCommand() {
         return new SequentialCommandGroup(
-            new InstantCommand(() -> shooter.idle()),
             new ParallelCommandGroup(
-                new AutoAlignWithHubCommand(limelight, drivetrain),
-                new AutoShootCommand(shooter, feeder, limelight, 1, false)));
+            new AutoAlignWithHubCommand(limelight, drivetrain),
+            new AutoShootCommand(shooter, feeder, limelight, 1, false)));
     }
 
     private Command createOneBallCommand() {
@@ -316,7 +315,6 @@ public class RobotContainer {
 /*     private Command createLeftTwoBallCommand() {
         return new SequentialCommandGroup(
             new InstantCommand(() -> drivetrain.resetPosition()),
-            new InstantCommand(() -> shooter.idle()),
             new AutoIntakeCommand(intake, feeder, IntakeMode.extended),
             new FollowerCommand(drivetrain, TrajectoryFactory.twoMetersForward),
             new ParallelCommandGroup(
@@ -326,7 +324,7 @@ public class RobotContainer {
     } */
 
     public Command createRightTwoBallCommand() {
-        return new SequentialCommandGroup(new InstantCommand(() -> shooter.idle()),
+        return new SequentialCommandGroup(
             new InstantCommand(() -> drivetrain.setAutoInitPose(new Pose2d(-0.5, -2, Rotation2d.fromDegrees(-90)))),
             new AutoIntakeCommand(intake, feeder, IntakeMode.extended),
             new FollowerCommand(drivetrain, TrajectoryFactory.start_ball2),
@@ -340,7 +338,7 @@ public class RobotContainer {
      * @return Command to perform 3 ball autonomous
      */
     private Command createThreeBallCommand() {
-        return new SequentialCommandGroup(new InstantCommand(() -> shooter.idle()),
+        return new SequentialCommandGroup(
             new InstantCommand(() -> drivetrain.setAutoInitPose(new Pose2d(-0.5, -2, Rotation2d.fromDegrees(-90)))),
             new AutoIntakeCommand(intake, feeder, IntakeMode.extended),
             new FollowerCommand(drivetrain, TrajectoryFactory.start_ball2),
@@ -360,7 +358,7 @@ public class RobotContainer {
      * @return Command to perform 5 ball autonomous
      */
     private Command createFiveBallCommand() {
-        return new SequentialCommandGroup(new InstantCommand(() -> shooter.idle()),
+        return new SequentialCommandGroup(
             new InstantCommand(() -> drivetrain.setAutoInitPose(new Pose2d(-0.5, -2, Rotation2d.fromDegrees(-90)))),
             new AutoIntakeCommand(intake, feeder, IntakeMode.extended),
             new FollowerCommand(drivetrain, TrajectoryFactory.start_ball2),

--- a/RapidReact/src/main/java/frc/robot/commands/AutoShootCommand.java
+++ b/RapidReact/src/main/java/frc/robot/commands/AutoShootCommand.java
@@ -45,7 +45,6 @@ public class AutoShootCommand extends CommandBase {
     // Called when the command is initially scheduled.
     @Override
     public void initialize() {
-        shooter.shoot();
 
         feeder.setFeedMode(FeedMode.PRESHOOT);
         stagingCargo = true;
@@ -111,7 +110,6 @@ public class AutoShootCommand extends CommandBase {
     @Override
     public void end(boolean interrupted) {
         feeder.setFeedMode(FeedMode.STOPPED);
-        shooter.idle();
 
         timer.stop();
 

--- a/RapidReact/src/main/java/frc/robot/commands/IdleShooterCommand.java
+++ b/RapidReact/src/main/java/frc/robot/commands/IdleShooterCommand.java
@@ -3,10 +3,10 @@ package frc.robot.commands;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.ShooterSubsystem;
 
-public class DefaultShooterCommand extends CommandBase {
+public class IdleShooterCommand extends CommandBase {
   ShooterSubsystem shooter;
   
-  public DefaultShooterCommand(ShooterSubsystem shooter) {
+  public IdleShooterCommand(ShooterSubsystem shooter) {
     this.shooter = shooter;
     addRequirements(shooter);
   }
@@ -20,7 +20,9 @@ public class DefaultShooterCommand extends CommandBase {
   public void execute() {}
 
   @Override
-  public void end(boolean interrupted) {}
+  public void end(boolean interrupted) {
+    shooter.shoot();
+  }
 
   @Override
   public boolean isFinished() {

--- a/RapidReact/src/main/java/frc/robot/commands/ShootCommand.java
+++ b/RapidReact/src/main/java/frc/robot/commands/ShootCommand.java
@@ -70,7 +70,6 @@ public class ShootCommand extends CommandBase {
     // Called when the command is initially scheduled.
     @Override
     public void initialize() {
-        shooter.shoot();
         feeder.setFeedMode(FeedMode.PRESHOOT);
         
         stagingCargo = true;
@@ -139,14 +138,12 @@ public class ShootCommand extends CommandBase {
     @Override
     public void end(boolean interrupted) {
         feeder.setFeedMode(FeedMode.STOPPED);
-        shooter.idle();
 
         shootReadyNotifier.accept(false);
 
         if (!fixedRange) {
             limelight.setLEDMode(limelight.LED_OFF);
         }
-
     }
 
     // Returns true when the command should end.


### PR DESCRIPTION
The shooter's default command now manages the idle mode switching instead of making each command that uses the shooter have to deal with it.

Also renamed the default command to IdleShooterCommand which seemed a little more descriptive.

Yvonne, please take a look at this change for handling of the idle mode and approve it if you think it is good.